### PR TITLE
make ingress configurable

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/ingress.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ .Chart.Name }}
 spec:
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ .Values.ingress.subdomain }}.{{ .Values.ingress.domain }}
     http:
       paths:
       - backend:
@@ -22,5 +22,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    - "{{ .Values.ingress.tls.subdomain }}.{{ .Values.ingress.domain }}"
     secretName: {{ .Values.ingress.tls.secretName }}

--- a/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
@@ -36,9 +36,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 100k
 
-  host: rcs.localhost
+  domain: localhost
+  subdomain: rcs
   tls:
-    secret: selfSignedCert
+    secretName: sslcert
+    subdomain: "*"
   
 service:
   apiVersion: v1


### PR DESCRIPTION
Allow the ingress to be configurable so we can set different domains/subdomains for both the host and tls cert.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs/issues/20