### PR TITLE
tag image as latest on merge

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker repo=${{ secrets.RELEASE_REPO }}
+          make docker tag=latest
 
       - name: helm version
         id: helm


### PR DESCRIPTION
Tag the image with latest on merge to master. unlike [rs](https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/pull/55). RCS is only tagging with the pr number on pull request so changes to the pr action is not needed.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/54