### PR TITLE
fix 502 error in nginx

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
@@ -31,7 +31,6 @@ ingress:
   apiVersion: extensions/v1beta1
   class: nginx
   additionalAnnotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/client-body-buffer-size: 1m
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 100k


### PR DESCRIPTION
RCS in dev cluster was returning 502 due to the https backend annotation inside its ingress.