### PR TITLE
forward to the correct service

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/ingress.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: rcs
+          serviceName: {{ .Chart.Name }}
           servicePort: 8080
         path: /
   tls:


### PR DESCRIPTION
Dev ingress should direct traffic to the correct service whose name is taken from the chart name.