### PR TITLE
add prometheus micrometer dependency

### DIFF
--- a/securebanking-openbanking-uk-rcs-sample/pom.xml
+++ b/securebanking-openbanking-uk-rcs-sample/pom.xml
@@ -103,6 +103,10 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/securebanking-openbanking-uk-rcs-sample/src/main/resources/application.yml
+++ b/securebanking-openbanking-uk-rcs-sample/src/main/resources/application.yml
@@ -17,7 +17,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, prometheus
+        include: health, info, prometheus
 
 #Swagger
 springfox:

--- a/securebanking-openbanking-uk-rcs-sample/src/main/resources/application.yml
+++ b/securebanking-openbanking-uk-rcs-sample/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
   profiles:
     active: NOT_SET
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+
 #Swagger
 springfox:
   documentation:


### PR DESCRIPTION
Following the spring [actuator guide](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html). Expose the prometheus metrics endpoint.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs/issues/26