### PR TITLE
add match labels and name the port

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/service.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/service.yaml
@@ -2,10 +2,13 @@ apiVersion: {{ .Values.service.apiVersion }}
 kind: Service
 metadata:
   name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: 8080
+  - name: {{ .Chart.Name }}
+    port: 8080
     targetPort: {{ .Values.deployment.server.port }}
     protocol: TCP
   selector:


### PR DESCRIPTION
Give the port a name for use with the prometheus service monitor manifest.
Our Prometheus ServiceMonitor [manifest](https://github.com/ForgeCloud/sbat-deploy/pull/38) needs to match a service via its `app` label - add `app` label with Chart name

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs/issues/26