### PR TITLE
add release, pr ad merge actions

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -42,25 +42,9 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          make docker repo=${{ secrets.RELEASE_REPO }}
-          make docker tag=latest
-
-      - name: helm version
-        id: helm
-        run: |
-          HELM_VERSION=$(make version)
-          echo ::set-output name=version::"$HELM_VERSION"
-
-      - name: package helm
-        run: |
-          make helm version=${{ steps.helm.outputs.version }}
-
-      - name: Publish Release Chart 
-        id: upload
-        uses: google-github-actions/upload-cloud-storage@main
-        with:
-          path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
-          destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}
+          make docker tag=${{ github.sha }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:{{ github.sha }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=${{ steps.tag.outputs.pr_number }}
+          make docker tag=${{ env.PR_NUMBER }}
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,24 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+
+      - name: helm version
+        id: helm
+        run: |
+          HELM_VERSION=$(make version)
+          echo ::set-output name=version::"$HELM_VERSION"
+
+      - name: package helm
+        run: |
+          make helm version=${{ steps.helm.outputs.version }}
+
+      - name: Publish Release Chart 
+        id: upload
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
+          destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}
+      
+      - name: Build Docker Image
+        run: |
+          make docker tag=${{ github.event.release.tag_name }} repo=${{ secrets.RELEASE_REPO }}


### PR DESCRIPTION
Add github sha to docker image on merge to master.
add github tag to docker image and push to release repo when a release is made

remove all release repo references from merge/pr actions.

Publishing a helm chart is not required at the merge or pr phase.

issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/89