### PR TITLE
311: Provide limits and JAVA_OPTS to control mem

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             httpGet:
               path: /actuator/health
               port: {{ .Values.deployment.server.port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 120
             periodSeconds: 5
             failureThreshold: 5
             successThreshold: 1
@@ -73,5 +73,7 @@ spec:
             value: "http://securebanking-spring-config-server:8080"
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"
+          - name: JAVA_OPTS
+            value: {{ .Values.deployment.java.opts }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
@@ -20,7 +20,16 @@ deployment:
   cors:
     originEnds: localhost
 
-  resources: {}
+  java:
+    opts: -XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -agentlib:jdwp=transport=dt_socket,address=*:9091,server=y,suspend=n
+
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 512Mi
+    limits:
+      cpu: 0.5
+      memory: 512Mi
 
 ingress:
   apiVersion: extensions/v1beta1
@@ -39,3 +48,4 @@ ingress:
 service:
   apiVersion: v1
   type: ClusterIP
+


### PR DESCRIPTION
Huge amount of CPU being requested at start up caused node issue and
eviction of pods. We need to change the way tomcat is started such
that it respects the container memory limits and has a guaranteed
quality of service.

Set the following java opts;
-XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50

Update the chart version as extension/v1beta1 is old and I was getting
warnings that is deprecated, and it simply won't deploy on newer
versions of k8s, e.g. in local minikube.

Note: These changes dramatically increase the start up time of the
RCS.This meant the pods were starting to fail as the liveness probe
wasn't responding in time. To address that I have increased the
`intitalDelaySeconds` value  on the liveness probe

Issue: SecureBankingAccessToolkit/SecureBankingAccessToolkit#311