### PR TITLE
458:  Updating license to include 2022 in year range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@
     <parent>
         <groupId>com.forgerock.securebanking</groupId>
         <artifactId>securebanking-parent</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/securebanking-forgerock-cloud-client/pom.xml
+++ b/securebanking-forgerock-cloud-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/ConsentStatusCode.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/ConsentStatusCode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/Constants.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/Constants.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/IntentType.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/IntentType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/configuration/ConfigurationPropertiesClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/configuration/ConfigurationPropertiesClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ErrorClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ErrorClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ErrorType.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ErrorType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ExceptionClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/exceptions/ExceptionClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ApiClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ApiClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/Consent.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/Consent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentDecision.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentDecision.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentDecisionData.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentDecisionData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentRequest.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/ConsentRequest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/User.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/models/User.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ApiClientServiceClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ApiClientServiceClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentService.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentServiceClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentServiceClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentServiceInterface.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/ConsentServiceInterface.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/JwkServiceClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/JwkServiceClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/UserServiceClient.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/services/UserServiceClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/utils/jwt/JwtUtil.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/utils/jwt/JwtUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/utils/url/UrlContext.java
+++ b/securebanking-forgerock-cloud-client/src/main/java/com/forgerock/securebanking/platform/client/utils/url/UrlContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/TestApplicationClient.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/TestApplicationClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/configuration/ConfigurationPropertiesClientTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/configuration/ConfigurationPropertiesClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/AccountConsentDetailsTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/AccountConsentDetailsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/ConsentDecisionTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/ConsentDecisionTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/DomesticPaymentConsentDetailsTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/models/DomesticPaymentConsentDetailsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/ApiClientServiceClientTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/ApiClientServiceClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/BaseServiceClientTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/BaseServiceClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/ConsentServiceTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/ConsentServiceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/UserServiceClientTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/services/UserServiceClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/AccountAccessConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/AccountAccessConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ApiClientTestDataFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ApiClientTestDataFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ConsentDecisionTestDataFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ConsentDecisionTestDataFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ConsentDetailsRequestTestDataFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/ConsentDetailsRequestTestDataFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticScheduledPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticScheduledPaymentConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticStandingOrderConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticStandingOrderConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalPaymentConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalScheduledPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalScheduledPaymentConsentDetailsTestFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/UserTestDataFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/UserTestDataFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/utils/url/UrlContextTest.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/utils/url/UrlContextTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/pom.xml
+++ b/securebanking-openbanking-uk-rcs-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApi.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApi.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApi.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApi.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/RedirectionAction.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/RedirectionAction.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/ConsentDecisionRequest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/ConsentDecisionRequest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/DomesticPaymentConsentDecision.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/DomesticPaymentConsentDecision.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/FundsConfirmationConsentDecision.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/decision/FundsConfirmationConsentDecision.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/AccountsConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/AccountsConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/ConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/ConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticPaymentConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticPaymentConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticScheduledPaymentConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticScheduledPaymentConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticStandingOrderConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/DomesticStandingOrderConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/FilePaymentConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/FilePaymentConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/FundsConfirmationConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/FundsConfirmationConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalPaymentConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalPaymentConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalScheduledPaymentConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalScheduledPaymentConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalStandingOrderConsentDetails.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/dto/consent/details/InternationalStandingOrderConsentDetails.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDecisionBuilderFactory.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDecisionBuilderFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDecisionConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDecisionConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDetailsBuilderFactory.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/ConsentDetailsBuilderFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/Converter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/general/Converter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/swagger/SwaggerApiTags.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/swagger/SwaggerApiTags.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/ConsentDetailsBuilderFactoryTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/ConsentDetailsBuilderFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter4Test.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter4Test.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-sample/pom.xml
+++ b/securebanking-openbanking-uk-rcs-sample/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-sample/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/RcsApplication.java
+++ b/securebanking-openbanking-uk-rcs-sample/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/RcsApplication.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/pom.xml
+++ b/securebanking-openbanking-uk-rcs-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiController.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiController.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiController.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiController.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/AccountService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/AccountService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/DomesticPaymentService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/rs/DomesticPaymentService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsApplicationConfiguration.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsApplicationConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationProperties.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationProperties.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RsBackofficeConfiguration.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RsBackofficeConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/swagger/SwaggerConfiguration.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/swagger/SwaggerConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/GlobalExceptionHandler.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/GlobalExceptionHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/InvalidConsentException.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/InvalidConsentException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/RcsErrorService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/exception/RcsErrorService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/util/AccountWithBalanceMatcher.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/util/AccountWithBalanceMatcher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/util/ConsentDecisionDeserializer.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/util/ConsentDecisionDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/RcsApplicationTestSupport.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/RcsApplicationTestSupport.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationPropertiesTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/RcsConfigurationPropertiesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/TestConfiguration.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/TestConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/swagger/SwaggerConfigurationTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/configuration/swagger/SwaggerConfigurationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/JwtTestHelper.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/JwtTestHelper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/AccountWithBalanceMatcherTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/AccountWithBalanceMatcherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/ConsentDecisionDeserializerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/ConsentDecisionDeserializerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated parent pom to 1.0.5-SNAPSHOT to pickup license changes, applied new license format which includes 2022 in the year range and formats the license as a block comment rather than javadoc.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/458