### PR TITLE
465: Adding international standing order consent decision

### DIFF
--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter4Test.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/UtilConverter4Test.java
@@ -32,7 +32,6 @@ public class UtilConverter4Test {
     public static final String INTERNATIONAL_SCHEDULED_PAYMENT_INTENT_ID = "PISC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
     public static final String INTERNATIONAL_STANDING_ORDER_INTENT_ID = "PISOC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
 
-
     public static final JsonElement transformationForPermissionsList(List<FRExternalPermissionsCode> list) {
         if (list == null || list.isEmpty()) {
             return null;

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
@@ -53,6 +53,7 @@ import static com.forgerock.securebanking.platform.client.test.support.DomesticS
 import static com.forgerock.securebanking.platform.client.test.support.DomesticStandingOrderConsentDetailsTestFactory.aValidDomesticStandingOrderConsentDetails;
 import static com.forgerock.securebanking.platform.client.test.support.InternationalPaymentConsentDetailsTestFactory.aValidInternationalPaymentConsentDetails;
 import static com.forgerock.securebanking.platform.client.test.support.InternationalScheduledPaymentConsentDetailsTestFactory.aValidInternationalScheduledPaymentConsentDetails;
+import static com.forgerock.securebanking.platform.client.test.support.InternationalStandingOrderConsentDetailsTestFactory.aValidInternationalStandingOrderConsentDetails;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -313,6 +314,46 @@ public class ConsentDecisionApiControllerTest {
 
         ConsentDecisionRequest consentDecisionRequest = ConsentDecisionRequest.builder()
                 .accountIds(convert(internationalScheduledPaymentConsentDetails.getAsJsonArray("accountsIds")))
+                .consentJwt(jwt)
+                .decision(Constants.ConsentDecision.AUTHORISED)
+                .debtorAccount(financialAccount)
+                .build();
+        HttpEntity<String> request = new HttpEntity(consentDecisionRequest, headers());
+
+        // when
+        ResponseEntity<RedirectionAction> response = restTemplate.postForEntity(consentDetailURL, request, RedirectionAction.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getConsentJwt()).isNotEmpty();
+        assertThat(response.getBody().getRedirectUri()).isNotEmpty();
+    }
+
+    @Test
+    public void ShouldGetRedirectionActionInternationalStandingOrder() throws ExceptionClient {
+        // given
+        ConsentDecision consentDecision = aValidDomesticPaymentConsentDecision(INTERNATIONAL_STANDING_ORDER_INTENT_ID);
+        JsonObject internationalStandingOrderConsentDetails = aValidInternationalStandingOrderConsentDetails(consentDecision.getIntentId());
+        given(consentServiceClient.updateConsent(consentDecision)).willReturn(internationalStandingOrderConsentDetails);
+        String jwt = JwtTestHelper.consentRequestJwt(
+                consentDecision.getClientId(),
+                consentDecision.getIntentId(),
+                consentDecision.getResourceOwnerUsername()
+        );
+
+        given(jwkServiceClient.signClaims(any(JWTClaimsSet.class), anyString())).willReturn(jwt);
+        String consentDetailURL = BASE_URL + port + CONTEXT_DETAILS_URI;
+
+        FRAccountIdentifier accountIdentifier = new FRAccountIdentifier();
+        accountIdentifier.setIdentification("76064512389965");
+        accountIdentifier.setName("John");
+        accountIdentifier.setSchemeName("UK.OBIE.SortCodeAccountNumber");
+        FRFinancialAccount financialAccount = new FRFinancialAccount();
+        financialAccount.setAccounts(List.of(accountIdentifier));
+
+        ConsentDecisionRequest consentDecisionRequest = ConsentDecisionRequest.builder()
+                .accountIds(convert(internationalStandingOrderConsentDetails.getAsJsonArray("accountsIds")))
                 .consentJwt(jwt)
                 .decision(Constants.ConsentDecision.AUTHORISED)
                 .debtorAccount(financialAccount)

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDecisionApiControllerTest.java
@@ -214,8 +214,8 @@ public class ConsentDecisionApiControllerTest {
     public void ShouldGetRedirectionActionDomesticStandingOrder() throws ExceptionClient {
         // given
         ConsentDecision consentDecision = aValidDomesticPaymentConsentDecision(DOMESTIC_STANDING_ORDER_INTENT_ID);
-        JsonObject domesticStrandingOrderConsentDetails = aValidDomesticStandingOrderConsentDetails(consentDecision.getIntentId());
-        given(consentServiceClient.updateConsent(consentDecision)).willReturn(domesticStrandingOrderConsentDetails);
+        JsonObject domesticStandingOrderConsentDetails = aValidDomesticStandingOrderConsentDetails(consentDecision.getIntentId());
+        given(consentServiceClient.updateConsent(consentDecision)).willReturn(domesticStandingOrderConsentDetails);
         String jwt = JwtTestHelper.consentRequestJwt(
                 consentDecision.getClientId(),
                 consentDecision.getIntentId(),
@@ -233,7 +233,7 @@ public class ConsentDecisionApiControllerTest {
         financialAccount.setAccounts(List.of(accountIdentifier));
 
         ConsentDecisionRequest consentDecisionRequest = ConsentDecisionRequest.builder()
-                .accountIds(convert(domesticStrandingOrderConsentDetails.getAsJsonArray("accountsIds")))
+                .accountIds(convert(domesticStandingOrderConsentDetails.getAsJsonArray("accountsIds")))
                 .consentJwt(jwt)
                 .decision(Constants.ConsentDecision.AUTHORISED)
                 .debtorAccount(financialAccount)

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
@@ -22,5 +22,5 @@ public class Constants {
     public static final String DOMESTIC_STANDING_ORDER_INTENT_ID = "PDSOC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
     public static final String INTERNATIONAL_PAYMENT_INTENT_ID = "PIC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
     public static final String INTERNATIONAL_SCHEDULED_PAYMENT_INTENT_ID = "PISC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
-    public static final String INTERNATIONAL_STANDING_ORDER_INTENT_ID = "PISC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
+    public static final String INTERNATIONAL_STANDING_ORDER_INTENT_ID = "PISOC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
 }

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/util/Constants.java
@@ -22,4 +22,5 @@ public class Constants {
     public static final String DOMESTIC_STANDING_ORDER_INTENT_ID = "PDSOC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
     public static final String INTERNATIONAL_PAYMENT_INTENT_ID = "PIC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
     public static final String INTERNATIONAL_SCHEDULED_PAYMENT_INTENT_ID = "PISC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
+    public static final String INTERNATIONAL_STANDING_ORDER_INTENT_ID = "PISC_1c214525-d0c8-4d13-xxx-b812c6fafabe";
 }


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/465
Description: Added support for international standing order consent decision.