### PR TITLE
522: Updating RCS to parse OBIntentObject from the IDM consent response

### DIFF
--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/AccountAccessConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/AccountAccessConsentDetailsTestFactory.java
@@ -50,7 +50,9 @@ public class AccountAccessConsentDetailsTestFactory {
     public static JsonObject aValidAccountConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidAccountConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidAccountConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "AISP Name");
@@ -62,7 +64,9 @@ public class AccountAccessConsentDetailsTestFactory {
     public static JsonObject aValidAccountConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidAccountConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidAccountConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "AISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticScheduledPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticScheduledPaymentConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class DomesticScheduledPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticScheduledPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticScheduledPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticScheduledPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class DomesticScheduledPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticScheduledPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticScheduledPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticScheduledPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticStandingOrderConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/DomesticStandingOrderConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class DomesticStandingOrderConsentDetailsTestFactory {
     public static JsonObject aValidDomesticStandingOrderConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticStandingOrderConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticStandingOrderConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class DomesticStandingOrderConsentDetailsTestFactory {
     public static JsonObject aValidDomesticStandingOrderConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidDomesticStandingOrderConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidDomesticStandingOrderConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalPaymentConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class InternationalPaymentConsentDetailsTestFactory {
     public static JsonObject aValidInternationalPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class InternationalPaymentConsentDetailsTestFactory {
     public static JsonObject aValidInternationalPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalScheduledPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalScheduledPaymentConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class InternationalScheduledPaymentConsentDetailsTestFactory {
     public static JsonObject aValidInternationalScheduledPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalScheduledPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalScheduledPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class InternationalScheduledPaymentConsentDetailsTestFactory {
     public static JsonObject aValidInternationalScheduledPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalScheduledPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalScheduledPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalStandingOrderConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-cloud-client/src/test/java/com/forgerock/securebanking/platform/client/test/support/InternationalStandingOrderConsentDetailsTestFactory.java
@@ -51,7 +51,9 @@ public class InternationalStandingOrderConsentDetailsTestFactory {
     public static JsonObject aValidInternationalStandingOrderConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalStandingOrderConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalStandingOrderConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -63,7 +65,9 @@ public class InternationalStandingOrderConsentDetailsTestFactory {
     public static JsonObject aValidInternationalStandingOrderConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", UUID.randomUUID().toString());
-        consent.add("data", aValidInternationalStandingOrderConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntent = new JsonObject();
+        obIntent.add("Data", aValidInternationalStandingOrderConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntent);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.AccountsConsentDetails;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,31 +52,35 @@ public class AccountConsentDetailsConverter {
         details.setAispName(isNotNull(consentDetails.get("oauth2ClientName")) ?
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
-        if (!isNotNull(consentDetails.get("data"))) {
-            details.setFromTransaction(null);
-            details.setToTransaction(null);
-            details.setExpiredDate(null);
-            details.setPermissions(null);
-        } else {
-            JsonObject data = consentDetails.getAsJsonObject("data");
 
-            details.setFromTransaction(isNotNull(data.get("TransactionFromDateTime")) ?
-                    DateTime.parse(data.get("TransactionFromDateTime").getAsString()) :
-                    null);
+        if (consentDetails.has("OBIntentObject")) {
+            final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
+            final JsonElement consentDataElement = obIntentObject.get("Data");
+            if (!isNotNull(consentDataElement)) {
+                details.setFromTransaction(null);
+                details.setToTransaction(null);
+                details.setExpiredDate(null);
+                details.setPermissions(null);
+            } else {
+                JsonObject data = consentDataElement.getAsJsonObject();
 
-            details.setToTransaction(isNotNull(data.get("TransactionToDateTime")) ?
-                    DateTime.parse(data.get("TransactionToDateTime").getAsString()) :
-                    null);
+                details.setFromTransaction(isNotNull(data.get("TransactionFromDateTime")) ?
+                        DateTime.parse(data.get("TransactionFromDateTime").getAsString()) :
+                        null);
 
-            details.setExpiredDate(isNotNull(data.get("ExpirationDateTime")) ?
-                    DateTime.parse(data.get("ExpirationDateTime").getAsString()) :
-                    null);
+                details.setToTransaction(isNotNull(data.get("TransactionToDateTime")) ?
+                        DateTime.parse(data.get("TransactionToDateTime").getAsString()) :
+                        null);
 
-            details.setPermissions(isNotNull(data.get("Permissions")) ?
-                    data.getAsJsonArray("Permissions") :
-                    null);
+                details.setExpiredDate(isNotNull(data.get("ExpirationDateTime")) ?
+                        DateTime.parse(data.get("ExpirationDateTime").getAsString()) :
+                        null);
+
+                details.setPermissions(isNotNull(data.get("Permissions")) ?
+                        data.getAsJsonArray("Permissions") :
+                        null);
+            }
         }
-
         return details;
     }
 

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverter.java
@@ -53,7 +53,9 @@ public class AccountConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
@@ -53,7 +53,9 @@ public class DomesticPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverter.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,27 +53,31 @@ public class DomesticPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (!isNotNull(consentDetails.get("data"))) {
-            details.setInstructedAmount(null);
-            details.setPaymentReference(null);
-        } else {
-            JsonObject data = consentDetails.getAsJsonObject("data");
+        if (consentDetails.has("OBIntentObject")) {
+            final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
+            final JsonElement consentDataElement = obIntentObject.get("Data");
+            if (!isNotNull(consentDataElement)) {
+                details.setInstructedAmount(null);
+                details.setPaymentReference(null);
+            } else {
+                JsonObject data = consentDataElement.getAsJsonObject();
 
-            if (isNotNull(data.get("Initiation"))) {
-                JsonObject initiation = data.getAsJsonObject("Initiation");
+                if (isNotNull(data.get("Initiation"))) {
+                    JsonObject initiation = data.getAsJsonObject("Initiation");
 
-                details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
-                        initiation.getAsJsonObject("InstructedAmount") :
-                        null);
+                    details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
+                            initiation.getAsJsonObject("InstructedAmount") :
+                            null);
 
-                details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) &&
-                        isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
-                        initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() :
-                        null);
+                    details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) &&
+                            isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
+                            initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() :
+                            null);
 
-                details.setCharges(isNotNull(data.get("Charges")) ?
-                        data.getAsJsonArray("Charges") :
-                        null);
+                    details.setCharges(isNotNull(data.get("Charges")) ?
+                            data.getAsJsonArray("Charges") :
+                            null);
+                }
             }
         }
         return details;

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverter.java
@@ -56,7 +56,9 @@ public class DomesticScheduledPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
@@ -17,6 +17,7 @@ package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticScheduledPaymentConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticStandingOrderConsentDetails;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,31 +57,35 @@ public class DomesticStandingOrderConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (!isNotNull(consentDetails.get("data"))) {
-            details.setPaymentReference(null);
-            details.setStandingOrder(null);
-        } else {
-            JsonObject data = consentDetails.getAsJsonObject("data");
+        if (consentDetails.has("OBIntentObject")) {
+            final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
+            final JsonElement consentDataElement = obIntentObject.get("Data");
+            if (!isNotNull(consentDataElement)) {
+                details.setPaymentReference(null);
+                details.setStandingOrder(null);
+            } else {
+                JsonObject data = consentDataElement.getAsJsonObject();
 
-            if (isNotNull(data.get("Initiation"))) {
-                JsonObject initiation = data.getAsJsonObject("Initiation");
+                if (isNotNull(data.get("Initiation"))) {
+                    JsonObject initiation = data.getAsJsonObject("Initiation");
 
-                details.setPaymentReference(isNotNull(initiation.get("Reference")) ?
-                        initiation.get("Reference").getAsString() : null);
+                    details.setPaymentReference(isNotNull(initiation.get("Reference")) ?
+                            initiation.get("Reference").getAsString() : null);
 
-                details.setStandingOrder(
-                        isNotNull(initiation.get("FinalPaymentDateTime")) ? initiation.get("FinalPaymentDateTime") : null,
-                        isNotNull(initiation.get("FinalPaymentAmount")) ? initiation.getAsJsonObject("FinalPaymentAmount") : null,
-                        isNotNull(initiation.get("FirstPaymentDateTime")) ? initiation.get("FirstPaymentDateTime") : null,
-                        isNotNull(initiation.get("FirstPaymentAmount")) ? initiation.getAsJsonObject("FirstPaymentAmount") : null,
-                        isNotNull(initiation.get("RecurringPaymentDateTime")) ? initiation.get("RecurringPaymentDateTime") : null,
-                        isNotNull(initiation.get("RecurringPaymentAmount")) ? initiation.getAsJsonObject("RecurringPaymentAmount") : null,
-                        initiation.get("Frequency")
-                );
+                    details.setStandingOrder(
+                            isNotNull(initiation.get("FinalPaymentDateTime")) ? initiation.get("FinalPaymentDateTime") : null,
+                            isNotNull(initiation.get("FinalPaymentAmount")) ? initiation.getAsJsonObject("FinalPaymentAmount") : null,
+                            isNotNull(initiation.get("FirstPaymentDateTime")) ? initiation.get("FirstPaymentDateTime") : null,
+                            isNotNull(initiation.get("FirstPaymentAmount")) ? initiation.getAsJsonObject("FirstPaymentAmount") : null,
+                            isNotNull(initiation.get("RecurringPaymentDateTime")) ? initiation.get("RecurringPaymentDateTime") : null,
+                            isNotNull(initiation.get("RecurringPaymentAmount")) ? initiation.getAsJsonObject("RecurringPaymentAmount") : null,
+                            initiation.get("Frequency")
+                    );
 
-                details.setCharges(isNotNull(data.get("Charges")) ?
-                        data.getAsJsonArray("Charges") :
-                        null);
+                    details.setCharges(isNotNull(data.get("Charges")) ?
+                            data.getAsJsonArray("Charges") :
+                            null);
+                }
             }
         }
         return details;

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverter.java
@@ -57,7 +57,9 @@ public class DomesticStandingOrderConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
@@ -56,7 +56,9 @@ public class InternationalPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverter.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.InternationalPaymentConsentDetails;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,34 +56,38 @@ public class InternationalPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (!isNotNull(consentDetails.get("data"))) {
-            details.setPaymentReference(null);
-            details.setCurrencyOfTransfer(null);
-            details.setExchangeRateInformation(null);
-            details.setInstructedAmount(null);
-        } else {
-            JsonObject data = consentDetails.getAsJsonObject("data");
+        if (consentDetails.has("OBIntentObject")) {
+            final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
+            final JsonElement consentDataElement = obIntentObject.get("Data");
+            if (!isNotNull(consentDataElement)) {
+                details.setPaymentReference(null);
+                details.setCurrencyOfTransfer(null);
+                details.setExchangeRateInformation(null);
+                details.setInstructedAmount(null);
+            } else {
+                JsonObject data = consentDataElement.getAsJsonObject();
 
-            details.setExchangeRateInformation(isNotNull(data.get("ExchangeRateInformation")) ?
-                    data.getAsJsonObject("ExchangeRateInformation") :
-                    null);
-
-            if (isNotNull(data.get("Initiation"))) {
-                JsonObject initiation = data.getAsJsonObject("Initiation");
-
-                details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) && isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
-                        initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() : null);
-
-                details.setCurrencyOfTransfer(isNotNull(initiation.get("CurrencyOfTransfer")) ?
-                        initiation.get("CurrencyOfTransfer").getAsString() : null);
-
-                details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
-                        initiation.getAsJsonObject("InstructedAmount") :
+                details.setExchangeRateInformation(isNotNull(data.get("ExchangeRateInformation")) ?
+                        data.getAsJsonObject("ExchangeRateInformation") :
                         null);
 
-                details.setCharges(isNotNull(data.get("Charges")) ?
-                        data.getAsJsonArray("Charges") :
-                        null);
+                if (isNotNull(data.get("Initiation"))) {
+                    JsonObject initiation = data.getAsJsonObject("Initiation");
+
+                    details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) && isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
+                            initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() : null);
+
+                    details.setCurrencyOfTransfer(isNotNull(initiation.get("CurrencyOfTransfer")) ?
+                            initiation.get("CurrencyOfTransfer").getAsString() : null);
+
+                    details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
+                            initiation.getAsJsonObject("InstructedAmount") :
+                            null);
+
+                    details.setCharges(isNotNull(data.get("Charges")) ?
+                            data.getAsJsonArray("Charges") :
+                            null);
+                }
             }
         }
         return details;

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
@@ -57,7 +57,9 @@ public class InternationalScheduledPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (consentDetails.has("OBIntentObject")) {
+        if (!consentDetails.has("OBIntentObject")) {
+            throw new IllegalStateException("Expected OBIntentObject field in json");
+        } else {
             final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
             final JsonElement consentDataElement = obIntentObject.get("Data");
             if (!isNotNull(consentDataElement)) {

--- a/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
+++ b/securebanking-openbanking-uk-rcs-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverter.java
@@ -17,6 +17,7 @@ package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.InternationalPaymentConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.InternationalScheduledPaymentConsentDetails;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,38 +57,42 @@ public class InternationalScheduledPaymentConsentDetailsConverter {
                 consentDetails.get("oauth2ClientName").getAsString() :
                 null);
 
-        if (!isNotNull(consentDetails.get("data"))) {
-            details.setPaymentReference(null);
-            details.setCurrencyOfTransfer(null);
-            details.setExchangeRateInformation(null);
-            details.setInstructedAmount(null);
-        } else {
-            JsonObject data = consentDetails.getAsJsonObject("data");
+        if (consentDetails.has("OBIntentObject")) {
+            final JsonObject obIntentObject = consentDetails.get("OBIntentObject").getAsJsonObject();
+            final JsonElement consentDataElement = obIntentObject.get("Data");
+            if (!isNotNull(consentDataElement)) {
+                details.setPaymentReference(null);
+                details.setCurrencyOfTransfer(null);
+                details.setExchangeRateInformation(null);
+                details.setInstructedAmount(null);
+            } else {
+                JsonObject data = consentDataElement.getAsJsonObject();
 
-            details.setExchangeRateInformation(isNotNull(data.get("ExchangeRateInformation")) ?
-                    data.getAsJsonObject("ExchangeRateInformation") :
-                    null);
-
-            if (isNotNull(data.get("Initiation"))) {
-                JsonObject initiation = data.getAsJsonObject("Initiation");
-
-                details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) && isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
-                        initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() : null);
-
-                details.setCurrencyOfTransfer(isNotNull(initiation.get("CurrencyOfTransfer")) ?
-                        initiation.get("CurrencyOfTransfer").getAsString() : null);
-
-                details.setPaymentDate(isNotNull(initiation.get("RequestedExecutionDateTime")) ?
-                        DATE_TIME_FORMATTER.parseDateTime(initiation.get("RequestedExecutionDateTime").getAsString()) :
+                details.setExchangeRateInformation(isNotNull(data.get("ExchangeRateInformation")) ?
+                        data.getAsJsonObject("ExchangeRateInformation") :
                         null);
 
-                details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
-                        initiation.getAsJsonObject("InstructedAmount") :
-                        null);
+                if (isNotNull(data.get("Initiation"))) {
+                    JsonObject initiation = data.getAsJsonObject("Initiation");
 
-                details.setCharges(isNotNull(data.get("Charges")) ?
-                        data.getAsJsonArray("Charges") :
-                        null);
+                    details.setPaymentReference(isNotNull(initiation.get("RemittanceInformation")) && isNotNull(initiation.getAsJsonObject("RemittanceInformation").get("Reference")) ?
+                            initiation.getAsJsonObject("RemittanceInformation").get("Reference").getAsString() : null);
+
+                    details.setCurrencyOfTransfer(isNotNull(initiation.get("CurrencyOfTransfer")) ?
+                            initiation.get("CurrencyOfTransfer").getAsString() : null);
+
+                    details.setPaymentDate(isNotNull(initiation.get("RequestedExecutionDateTime")) ?
+                            DATE_TIME_FORMATTER.parseDateTime(initiation.get("RequestedExecutionDateTime").getAsString()) :
+                            null);
+
+                    details.setInstructedAmount(isNotNull(initiation.get("InstructedAmount")) ?
+                            initiation.getAsJsonObject("InstructedAmount") :
+                            null);
+
+                    details.setCharges(isNotNull(data.get("Charges")) ?
+                            data.getAsJsonArray("Charges") :
+                            null);
+                }
             }
         }
         return details;

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/AccountConsentDetailsConverterTest.java
@@ -18,6 +18,8 @@ package com.forgerock.securebanking.openbanking.uk.rcs.converters;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.AccountsConsentDetails;
 import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
+import springfox.documentation.spring.web.json.Json;
+
 import org.junit.jupiter.api.Test;
 
 import static com.forgerock.securebanking.openbanking.uk.rcs.converters.UtilConverter4Test.ACCOUNT_INTENT_ID;
@@ -41,33 +43,36 @@ public class AccountConsentDetailsConverterTest {
         AccountsConsentDetails accountsConsentDetails = AccountConsentDetailsConverter.getInstance().toAccountConsentDetails(consentDetails);
 
         // Then
+        final JsonObject consentDetailsData = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
         assertThat(transformationForPermissionsList(accountsConsentDetails.getPermissions()))
-                .isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonArray("Permissions"));
+                .isEqualTo(consentDetailsData.getAsJsonArray("Permissions"));
 
         assertThat(accountsConsentDetails.getFromTransaction().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("TransactionFromDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("TransactionFromDateTime").getAsString());
 
         assertThat(accountsConsentDetails.getToTransaction().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("TransactionToDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("TransactionToDateTime").getAsString());
 
         assertThat(accountsConsentDetails.getAispName()).isEqualTo(consentDetails.get("oauth2ClientName").getAsString());
 
         assertThat(accountsConsentDetails.getExpiredDate().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("ExpirationDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("ExpirationDateTime").getAsString());
     }
 
     @Test
     public void shouldConvertConsentDetailsOnlyMandatoryFieldsToAccountsConsentDetails() {
         // Given
         JsonObject consentDetails = aValidAccountConsentDetails(ACCOUNT_INTENT_ID);
-        consentDetails.add("data", aValidAccountConsentDataDetailsBuilderOnlyMandatoryFields(ACCOUNT_INTENT_ID));
+        final JsonObject obIntentObject = new JsonObject();
+        obIntentObject.add("Data", aValidAccountConsentDataDetailsBuilderOnlyMandatoryFields(ACCOUNT_INTENT_ID));
+        consentDetails.add("OBIntentObject", obIntentObject);
 
         // When
         AccountsConsentDetails accountsConsentDetails = AccountConsentDetailsConverter.getInstance().toAccountConsentDetails(consentDetails);
 
         // Then
         assertThat(transformationForPermissionsList(accountsConsentDetails.getPermissions()))
-                .isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonArray("Permissions"));
+                .isEqualTo(consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data").getAsJsonArray("Permissions"));
 
         assertThat(accountsConsentDetails.getFromTransaction()).isNull();
         assertThat(accountsConsentDetails.getToTransaction()).isNull();

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/ConsentDetailsBuilderFactoryTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/ConsentDetailsBuilderFactoryTest.java
@@ -44,19 +44,20 @@ public class ConsentDetailsBuilderFactoryTest {
         ConsentRequest consentDetailsRequest = ConsentDetailsRequestTestDataFactory.aValidAccountConsentDetailsRequest();
         AccountsConsentDetails accountsConsentDetails = (AccountsConsentDetails) ConsentDetailsBuilderFactory.build(consentDetails, consentDetailsRequest, apiClient);
         // Then
+        final JsonObject consentDetailsData = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
         assertThat(transformationForPermissionsList(accountsConsentDetails.getPermissions()))
-                .isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonArray("Permissions"));
+                .isEqualTo(consentDetailsData.getAsJsonArray("Permissions"));
 
         assertThat(accountsConsentDetails.getFromTransaction().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("TransactionFromDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("TransactionFromDateTime").getAsString());
 
         assertThat(accountsConsentDetails.getToTransaction().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("TransactionToDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("TransactionToDateTime").getAsString());
 
         assertThat(accountsConsentDetails.getAispName()).isEqualTo(consentDetails.get("oauth2ClientName").getAsString());
 
         assertThat(accountsConsentDetails.getExpiredDate().toString())
-                .isEqualTo(consentDetails.getAsJsonObject("data").get("ExpirationDateTime").getAsString());
+                .isEqualTo(consentDetailsData.get("ExpirationDateTime").getAsString());
     }
 
 

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticPaymentConsentDetailsConverterTest.java
@@ -39,7 +39,7 @@ public class DomesticPaymentConsentDetailsConverterTest {
         DomesticPaymentConsentDetails domesticPaymentConsentDetails = DomesticPaymentConsentDetailsConverter.getInstance().toDomesticPaymentConsentDetails(consentDetails);
 
         // Then
-        JsonObject initiation = consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation");
+        JsonObject initiation = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data").getAsJsonObject("Initiation");
 
         assertThat(domesticPaymentConsentDetails.getInstructedAmount().getAmount())
                 .isEqualTo(initiation.getAsJsonObject("InstructedAmount").get("Amount").getAsString());

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticScheduledPaymentConsentDetailsConverterTest.java
@@ -39,7 +39,7 @@ public class DomesticScheduledPaymentConsentDetailsConverterTest {
         DomesticScheduledPaymentConsentDetails domesticScheduledPaymentConsentDetails = DomesticScheduledPaymentConsentDetailsConverter.getInstance().toDomesticScheduledPaymentConsentDetails(consentDetails);
 
         // Then
-        JsonObject initiation = consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation");
+        JsonObject initiation = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data").getAsJsonObject("Initiation");
 
         assertThat(domesticScheduledPaymentConsentDetails.getInstructedAmount().getAmount())
                 .isEqualTo(initiation.getAsJsonObject("InstructedAmount").get("Amount").getAsString());

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/DomesticStandingOrderConsentDetailsConverterTest.java
@@ -39,7 +39,7 @@ public class DomesticStandingOrderConsentDetailsConverterTest {
         DomesticStandingOrderConsentDetails domesticStandingOrderConsentDetails = DomesticStandingOrderConsentDetailsConverter.getInstance().toDomesticStandingOrderConsentDetails(consentDetails);
 
         // Then
-        JsonObject initiation = consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation");
+        JsonObject initiation = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data").getAsJsonObject("Initiation");
 
         assertThat(domesticStandingOrderConsentDetails.getStandingOrder().getFinalPaymentAmount().getAmount())
                 .isEqualTo(initiation.getAsJsonObject("FinalPaymentAmount").get("Amount").getAsString());

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalPaymentConsentDetailsConverterTest.java
@@ -42,7 +42,7 @@ public class InternationalPaymentConsentDetailsConverterTest {
         InternationalPaymentConsentDetails internationalPaymentConsentDetails = InternationalPaymentConsentDetailsConverter.getInstance().toInternationalPaymentConsentDetails(consentDetails);
 
         // Then
-        JsonObject data = consentDetails.getAsJsonObject("data");
+        JsonObject data = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
         JsonObject initiation = data.getAsJsonObject("Initiation");
 
         assertThat(internationalPaymentConsentDetails.getInstructedAmount().getAmount())

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalScheduledPaymentConsentDetailsConverterTest.java
@@ -42,7 +42,7 @@ public class InternationalScheduledPaymentConsentDetailsConverterTest {
         InternationalScheduledPaymentConsentDetails internationalScheduledPaymentConsentDetails = InternationalScheduledPaymentConsentDetailsConverter.getInstance().toInternationalScheduledPaymentConsentDetails(consentDetails);
 
         // Then
-        JsonObject data = consentDetails.getAsJsonObject("data");
+        JsonObject data = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
         JsonObject initiation = data.getAsJsonObject("Initiation");
 
         assertThat(internationalScheduledPaymentConsentDetails.getInstructedAmount().getAmount())

--- a/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalStandingOrderConsentDetailsConverterTest.java
+++ b/securebanking-openbanking-uk-rcs-api/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/converters/InternationalStandingOrderConsentDetailsConverterTest.java
@@ -38,7 +38,7 @@ public class InternationalStandingOrderConsentDetailsConverterTest {
         InternationalStandingOrderConsentDetails internationalStandingOrderConsentDetails = InternationalStandingOrderConsentDetailsConverter.getInstance().toInternationalStandingOrderConsentDetails(consentDetails);
 
         // Then
-        JsonObject data = consentDetails.getAsJsonObject("data");
+        JsonObject data = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
         JsonObject initiation = data.getAsJsonObject("Initiation");
 
         assertThat(internationalStandingOrderConsentDetails.getInternationalStandingOrder().getInstructedAmount().getAmount())

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/api/ConsentDetailsApiControllerTest.java
@@ -392,7 +392,7 @@ public class ConsentDetailsApiControllerTest {
         assertThat(responseBody.getUsername()).isEqualTo(consentDetailsRequest.getUser().getUserName());
         assertThat(responseBody.getClientId()).isEqualTo(consentDetailsRequest.getClientId());
         assertThat(responseBody.getLogo()).isEqualTo(apiClient.getLogoUri());
-        assertThat(responseBody.getPaymentDate().isEqual(DATE_TIME_FORMATTER.parseDateTime(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").get("RequestedExecutionDateTime").getAsString())));
+        assertThat(responseBody.getPaymentDate().isEqual(DATE_TIME_FORMATTER.parseDateTime(consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data").getAsJsonObject("Initiation").get("RequestedExecutionDateTime").getAsString())));
     }
 
     @Test
@@ -524,20 +524,21 @@ public class ConsentDetailsApiControllerTest {
         assertThat(responseBody.getClientId()).isEqualTo(consentDetailsRequest.getClientId());
         assertThat(responseBody.getLogo()).isEqualTo(apiClient.getLogoUri());
 
-        assertThat(responseBody.getStandingOrder().getFinalPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").get("FinalPaymentDateTime").getAsString())));
-        assertThat(responseBody.getStandingOrder().getFirstPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").get("FirstPaymentDateTime").getAsString())));
-        assertThat(responseBody.getStandingOrder().getRecurringPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").get("RecurringPaymentDateTime").getAsString())));
+        final JsonObject expectedIntentData = consentDetails.getAsJsonObject("OBIntentObject").getAsJsonObject("Data");
+        assertThat(responseBody.getStandingOrder().getFinalPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(expectedIntentData.getAsJsonObject("Initiation").get("FinalPaymentDateTime").getAsString())));
+        assertThat(responseBody.getStandingOrder().getFirstPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(expectedIntentData.getAsJsonObject("Initiation").get("FirstPaymentDateTime").getAsString())));
+        assertThat(responseBody.getStandingOrder().getRecurringPaymentDateTime().isEqual(DATE_TIME_FORMATTER.parseDateTime(expectedIntentData.getAsJsonObject("Initiation").get("RecurringPaymentDateTime").getAsString())));
 
-        assertThat(responseBody.getStandingOrder().getFrequency()).isEqualTo((new FRFrequency(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").get("Frequency").getAsString())).getSentence());
+        assertThat(responseBody.getStandingOrder().getFrequency()).isEqualTo((new FRFrequency(expectedIntentData.getAsJsonObject("Initiation").get("Frequency").getAsString())).getSentence());
 
-        assertThat(responseBody.getStandingOrder().getFinalPaymentAmount().getAmount()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("FinalPaymentAmount").get("Amount").getAsString());
-        assertThat(responseBody.getStandingOrder().getFinalPaymentAmount().getCurrency()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("FinalPaymentAmount").get("Currency").getAsString());
+        assertThat(responseBody.getStandingOrder().getFinalPaymentAmount().getAmount()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("FinalPaymentAmount").get("Amount").getAsString());
+        assertThat(responseBody.getStandingOrder().getFinalPaymentAmount().getCurrency()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("FinalPaymentAmount").get("Currency").getAsString());
 
-        assertThat(responseBody.getStandingOrder().getFirstPaymentAmount().getAmount()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("FirstPaymentAmount").get("Amount").getAsString());
-        assertThat(responseBody.getStandingOrder().getFirstPaymentAmount().getCurrency()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("FirstPaymentAmount").get("Currency").getAsString());
+        assertThat(responseBody.getStandingOrder().getFirstPaymentAmount().getAmount()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("FirstPaymentAmount").get("Amount").getAsString());
+        assertThat(responseBody.getStandingOrder().getFirstPaymentAmount().getCurrency()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("FirstPaymentAmount").get("Currency").getAsString());
 
-        assertThat(responseBody.getStandingOrder().getRecurringPaymentAmount().getAmount()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("RecurringPaymentAmount").get("Amount").getAsString());
-        assertThat(responseBody.getStandingOrder().getRecurringPaymentAmount().getCurrency()).isEqualTo(consentDetails.getAsJsonObject("data").getAsJsonObject("Initiation").getAsJsonObject("RecurringPaymentAmount").get("Currency").getAsString());
+        assertThat(responseBody.getStandingOrder().getRecurringPaymentAmount().getAmount()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("RecurringPaymentAmount").get("Amount").getAsString());
+        assertThat(responseBody.getStandingOrder().getRecurringPaymentAmount().getCurrency()).isEqualTo(expectedIntentData.getAsJsonObject("Initiation").getAsJsonObject("RecurringPaymentAmount").get("Currency").getAsString());
     }
 
     @Test


### PR DESCRIPTION
IG RepoConsent route now returns OBIntentObject in the response, previously it returned the intents Data field, updating RCS to parse the new response structure

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/522